### PR TITLE
fixed typo in NcxReader.py

### DIFF
--- a/python3/NcxReader.py
+++ b/python3/NcxReader.py
@@ -60,13 +60,13 @@ class Navicat12Crypto(Navicat11Crypto):
 
     def EncryptStringForNCX(self, s : str):
         cipher = AES.new(b'libcckeylibcckey', AES.MODE_CBC, iv = b'libcciv libcciv ')
-        padded_plaintext = Padding.pad(s.encode('ascii'), AES.block_size, stype = 'pkcs7')
+        padded_plaintext = Padding.pad(s.encode('ascii'), AES.block_size, style = 'pkcs7')
         return cipher.encrypt(padded_plaintext).hex().upper()
 
     def DecryptStringForNCX(self, s : str):
         cipher = AES.new(b'libcckeylibcckey', AES.MODE_CBC, iv = b'libcciv libcciv ')
         padded_plaintext = cipher.decrypt(bytes.fromhex(s))
-        return Padding.unpad(padded_plaintext, AES.block_size, stype = 'pkcs7').decode('ascii')
+        return Padding.unpad(padded_plaintext, AES.block_size, style = 'pkcs7').decode('ascii')
 
 def TryDecrypt(cipher, s):
     try:


### PR DESCRIPTION
There are typos in NcxReader.py at lines 63 and 69.
It is shown **stype** = 'pkcs7' but it should be **style** = 'pkcs7'
